### PR TITLE
Add command line argument to place currency symbol before price

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub async fn get_history_for_stock(
     currency_commodity_name: String,
     separator: char,
     decimal_digits: Option<usize>,
+    currency_symbol_before: bool,
 ) {
     let stock_name = stock_commodity_name;
     let search = get_alpha_vantage_client()
@@ -105,9 +106,16 @@ pub async fn get_history_for_stock(
             price_string = price_string.replace('.', &separator.to_string());
         }
 
-        println!(
-            "P {} {} {} {}",
-            current_datetime, stock_name, price_string, currency_commodity_name
-        );
+        if currency_symbol_before {
+            println!(
+                "P {} {} {}{}",
+                current_datetime, stock_name, currency_commodity_name, price_string
+            );
+        } else {
+            println!(
+                "P {} {} {} {}",
+                current_datetime, stock_name, price_string, currency_commodity_name
+            );
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,12 @@ enum Command {
             help = "What character to use as decimal separator"
         )]
         separator: char,
+        #[clap(
+            short,
+            long,
+            help = "Whether to place the currency symbol before or after the amount."
+        )]
+        commodity_symbol_before: bool,
     },
 }
 
@@ -53,6 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             decimal_digits,
             separator,
             currency_commodity_name,
+            commodity_symbol_before,
         } => {
             hledger_get_market_prices::get_history_for_stock(
                 stock_symbol,
@@ -60,6 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 currency_commodity_name,
                 separator,
                 decimal_digits,
+                commodity_symbol_before,
             )
             .await
         }


### PR DESCRIPTION
In US dollars, you often put the dollar sign before the price amount, so I've added an option to move the location of the currency symbol.